### PR TITLE
Add label-enforcer workflow

### DIFF
--- a/.github/workflows/label-enforcer.yaml
+++ b/.github/workflows/label-enforcer.yaml
@@ -1,0 +1,15 @@
+name: Enforce Labels
+
+on:
+  pull_request:
+    types: [opened, edited, labeled, unlabeled, synchronize]
+jobs:
+  enforce-label:
+    permissions:
+      contents: read # for TimonVS/pr-labeler-action to read config file
+      pull-requests: write # for TimonVS/pr-labeler-action to add labels in PR
+    runs-on: ubuntu-latest
+    steps:
+    - uses: TimonVS/pr-labeler-action@v5
+      with:
+        repo-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This is a common workflow between our qdrant cloud repositories.