### PR TITLE
Provide a name, so we can use this name to access the protos from other GH repos

### DIFF
--- a/buf.yaml
+++ b/buf.yaml
@@ -2,6 +2,7 @@
 version: v2
 modules:
   - path: proto
+    name: github.com/qdrant/qdrant-cloud-public-api
 
 deps:
   - buf.build/googleapis/googleapis


### PR DESCRIPTION
I want to use common.proto from within the api-gateway repo to generate a unit test. Previously all code was in a single repo, now I need to do cross repo.