### PR TITLE
Execute buf-ci action only on pull_request events

### DIFF
--- a/.github/workflows/buf-ci.yaml
+++ b/.github/workflows/buf-ci.yaml
@@ -1,9 +1,7 @@
 name: Buf CI
 on:
-  push:
   pull_request:
     types: [opened, synchronize, reopened, labeled, unlabeled]
-  delete:
 permissions:
   contents: read
   pull-requests: write


### PR DESCRIPTION
Currently the action is failing because it tries to archive a label on the BSR (which we are not using).