### PR TITLE
Remove commented code for `GetAPIVersion` methods

### DIFF
--- a/gen/go/qdrant/cloud/booking/v2/booking.pb.go
+++ b/gen/go/qdrant/cloud/booking/v2/booking.pb.go
@@ -147,7 +147,7 @@ func (x *ListPackagesResponse) GetItems() []*Package {
 	return nil
 }
 
-// GetAPIVersionRequest is the request for the GetAPIVersion function
+// GetPackageRequest is the request for the GetPackage function
 type GetPackageRequest struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
 	// The identifier of the account (in Guid format).

--- a/gen/python/qdrant/cloud/auth/v2/auth_pb2_grpc.py
+++ b/gen/python/qdrant/cloud/auth/v2/auth_pb2_grpc.py
@@ -7,18 +7,6 @@ from qdrant.cloud.auth.v2 import auth_pb2 as qdrant_dot_cloud_dot_auth_dot_v2_do
 
 class AuthServiceStub(object):
     """AuthService is the API used to configure the auth settings (like api-key objects) for a cluster.
-    TODO:
-    // Get the current API version of this service.
-    // Required permissions:
-    // - None (authenticated only)
-    rpc GetAPIVersion(GetAPIVersionRequest) returns (GetAPIVersionResponse) {
-    // permissions
-    option (qdrant.cloud.common.v1.permissions) = "";
-    // custom account-id expression
-    option (qdrant.cloud.common.v1.account_id_expression) = "";
-    // gRPC Gateway REST call
-    option (google.api.http) = {get: "/api/auth/v2/api-version"};
-    }
     """
 
     def __init__(self, channel):
@@ -46,18 +34,6 @@ class AuthServiceStub(object):
 
 class AuthServiceServicer(object):
     """AuthService is the API used to configure the auth settings (like api-key objects) for a cluster.
-    TODO:
-    // Get the current API version of this service.
-    // Required permissions:
-    // - None (authenticated only)
-    rpc GetAPIVersion(GetAPIVersionRequest) returns (GetAPIVersionResponse) {
-    // permissions
-    option (qdrant.cloud.common.v1.permissions) = "";
-    // custom account-id expression
-    option (qdrant.cloud.common.v1.account_id_expression) = "";
-    // gRPC Gateway REST call
-    option (google.api.http) = {get: "/api/auth/v2/api-version"};
-    }
     """
 
     def ListApiKeys(self, request, context):
@@ -117,18 +93,6 @@ def add_AuthServiceServicer_to_server(servicer, server):
  # This class is part of an EXPERIMENTAL API.
 class AuthService(object):
     """AuthService is the API used to configure the auth settings (like api-key objects) for a cluster.
-    TODO:
-    // Get the current API version of this service.
-    // Required permissions:
-    // - None (authenticated only)
-    rpc GetAPIVersion(GetAPIVersionRequest) returns (GetAPIVersionResponse) {
-    // permissions
-    option (qdrant.cloud.common.v1.permissions) = "";
-    // custom account-id expression
-    option (qdrant.cloud.common.v1.account_id_expression) = "";
-    // gRPC Gateway REST call
-    option (google.api.http) = {get: "/api/auth/v2/api-version"};
-    }
     """
 
     @staticmethod

--- a/gen/python/qdrant/cloud/backup/v1/backup_pb2_grpc.py
+++ b/gen/python/qdrant/cloud/backup/v1/backup_pb2_grpc.py
@@ -7,18 +7,6 @@ from qdrant.cloud.backup.v1 import backup_pb2 as qdrant_dot_cloud_dot_backup_dot
 
 class BackupServiceStub(object):
     """BackupService is the API used to configure backup objects.
-    TODO:
-    // Get the current API version of this service.
-    // Required permissions:
-    // - None (authenticated only)
-    rpc GetAPIVersion(GetAPIVersionRequest) returns (GetAPIVersionResponse) {
-    // permissions
-    option (common.v1.permissions) = "";
-    // custom account-id expression
-    option (qdrant.cloud.common.v1.account_id_expression) = "";
-    // gRPC Gateway REST call
-    option (google.api.http) = {get: "/api/backup/v1/api-version"};
-    }
     """
 
     def __init__(self, channel):
@@ -76,18 +64,6 @@ class BackupServiceStub(object):
 
 class BackupServiceServicer(object):
     """BackupService is the API used to configure backup objects.
-    TODO:
-    // Get the current API version of this service.
-    // Required permissions:
-    // - None (authenticated only)
-    rpc GetAPIVersion(GetAPIVersionRequest) returns (GetAPIVersionResponse) {
-    // permissions
-    option (common.v1.permissions) = "";
-    // custom account-id expression
-    option (qdrant.cloud.common.v1.account_id_expression) = "";
-    // gRPC Gateway REST call
-    option (google.api.http) = {get: "/api/backup/v1/api-version"};
-    }
     """
 
     def ListBackups(self, request, context):
@@ -227,18 +203,6 @@ def add_BackupServiceServicer_to_server(servicer, server):
  # This class is part of an EXPERIMENTAL API.
 class BackupService(object):
     """BackupService is the API used to configure backup objects.
-    TODO:
-    // Get the current API version of this service.
-    // Required permissions:
-    // - None (authenticated only)
-    rpc GetAPIVersion(GetAPIVersionRequest) returns (GetAPIVersionResponse) {
-    // permissions
-    option (common.v1.permissions) = "";
-    // custom account-id expression
-    option (qdrant.cloud.common.v1.account_id_expression) = "";
-    // gRPC Gateway REST call
-    option (google.api.http) = {get: "/api/backup/v1/api-version"};
-    }
     """
 
     @staticmethod

--- a/gen/python/qdrant/cloud/booking/v2/booking_pb2_grpc.py
+++ b/gen/python/qdrant/cloud/booking/v2/booking_pb2_grpc.py
@@ -7,18 +7,6 @@ from qdrant.cloud.booking.v2 import booking_pb2 as qdrant_dot_cloud_dot_booking_
 
 class BookingServiceStub(object):
     """BookingService is the API used to configure the booking settings (like packages objects).
-    TODO:
-    // Get the current API version of this service.
-    // Required permissions:
-    // - None (authenticated only)
-    rpc GetAPIVersion(GetAPIVersionRequest) returns (GetAPIVersionResponse) {
-    // permissions
-    option (common.v1.permissions) = "";
-    // custom account-id expression
-    option (qdrant.cloud.common.v1.account_id_expression) = "";
-    // gRPC Gateway REST call
-    option (google.api.http) = {get: "/api/booking/v2/api-version"};
-    }
     """
 
     def __init__(self, channel):
@@ -41,18 +29,6 @@ class BookingServiceStub(object):
 
 class BookingServiceServicer(object):
     """BookingService is the API used to configure the booking settings (like packages objects).
-    TODO:
-    // Get the current API version of this service.
-    // Required permissions:
-    // - None (authenticated only)
-    rpc GetAPIVersion(GetAPIVersionRequest) returns (GetAPIVersionResponse) {
-    // permissions
-    option (common.v1.permissions) = "";
-    // custom account-id expression
-    option (qdrant.cloud.common.v1.account_id_expression) = "";
-    // gRPC Gateway REST call
-    option (google.api.http) = {get: "/api/booking/v2/api-version"};
-    }
     """
 
     def ListPackages(self, request, context):
@@ -96,18 +72,6 @@ def add_BookingServiceServicer_to_server(servicer, server):
  # This class is part of an EXPERIMENTAL API.
 class BookingService(object):
     """BookingService is the API used to configure the booking settings (like packages objects).
-    TODO:
-    // Get the current API version of this service.
-    // Required permissions:
-    // - None (authenticated only)
-    rpc GetAPIVersion(GetAPIVersionRequest) returns (GetAPIVersionResponse) {
-    // permissions
-    option (common.v1.permissions) = "";
-    // custom account-id expression
-    option (qdrant.cloud.common.v1.account_id_expression) = "";
-    // gRPC Gateway REST call
-    option (google.api.http) = {get: "/api/booking/v2/api-version"};
-    }
     """
 
     @staticmethod

--- a/gen/python/qdrant/cloud/booking/v2/booking_pydantic_schemas.py
+++ b/gen/python/qdrant/cloud/booking/v2/booking_pydantic_schemas.py
@@ -76,7 +76,7 @@ class ListPackagesResponse(BaseModel):
 
 class GetPackageRequest(BaseModel):
     """
-     GetAPIVersionRequest is the request for the GetAPIVersion function
+     GetPackageRequest is the request for the GetPackage function
     """
 
 # The identifier of the account (in Guid format).

--- a/gen/python/qdrant/cloud/cluster/v2/cluster_pb2_grpc.py
+++ b/gen/python/qdrant/cloud/cluster/v2/cluster_pb2_grpc.py
@@ -7,18 +7,6 @@ from qdrant.cloud.cluster.v2 import cluster_pb2 as qdrant_dot_cloud_dot_cluster_
 
 class ClusterServiceStub(object):
     """ClusterService is the API used to configure cluster objects.
-    TODO:
-    // Get the current API version of this service.
-    // Required permissions:
-    // - None (authenticated only)
-    rpc GetAPIVersion(GetAPIVersionRequest) returns (GetAPIVersionResponse) {
-    // permissions
-    option (common.v1.permissions) = "";
-    // custom account-id expression
-    option (qdrant.cloud.common.v1.account_id_expression) = "";
-    // gRPC Gateway REST call
-    option (google.api.http) = {get: "/api/cluster/v2/api-version"};
-    }
     """
 
     def __init__(self, channel):
@@ -81,18 +69,6 @@ class ClusterServiceStub(object):
 
 class ClusterServiceServicer(object):
     """ClusterService is the API used to configure cluster objects.
-    TODO:
-    // Get the current API version of this service.
-    // Required permissions:
-    // - None (authenticated only)
-    rpc GetAPIVersion(GetAPIVersionRequest) returns (GetAPIVersionResponse) {
-    // permissions
-    option (common.v1.permissions) = "";
-    // custom account-id expression
-    option (qdrant.cloud.common.v1.account_id_expression) = "";
-    // gRPC Gateway REST call
-    option (google.api.http) = {get: "/api/cluster/v2/api-version"};
-    }
     """
 
     def ListClusters(self, request, context):
@@ -249,18 +225,6 @@ def add_ClusterServiceServicer_to_server(servicer, server):
  # This class is part of an EXPERIMENTAL API.
 class ClusterService(object):
     """ClusterService is the API used to configure cluster objects.
-    TODO:
-    // Get the current API version of this service.
-    // Required permissions:
-    // - None (authenticated only)
-    rpc GetAPIVersion(GetAPIVersionRequest) returns (GetAPIVersionResponse) {
-    // permissions
-    option (common.v1.permissions) = "";
-    // custom account-id expression
-    option (qdrant.cloud.common.v1.account_id_expression) = "";
-    // gRPC Gateway REST call
-    option (google.api.http) = {get: "/api/cluster/v2/api-version"};
-    }
     """
 
     @staticmethod

--- a/gen/typescript/qdrant/cloud/auth/v2/auth_pb.ts
+++ b/gen/typescript/qdrant/cloud/auth/v2/auth_pb.ts
@@ -221,19 +221,6 @@ export const ApiKeySchema: GenMessage<ApiKey> = /*@__PURE__*/
 /**
  * AuthService is the API used to configure the auth settings (like api-key objects) for a cluster.
  *
- * TODO:
- * // Get the current API version of this service.
- * // Required permissions:
- * // - None (authenticated only)
- * rpc GetAPIVersion(GetAPIVersionRequest) returns (GetAPIVersionResponse) {
- * // permissions
- * option (qdrant.cloud.common.v1.permissions) = "";
- * // custom account-id expression
- * option (qdrant.cloud.common.v1.account_id_expression) = "";
- * // gRPC Gateway REST call
- * option (google.api.http) = {get: "/api/auth/v2/api-version"};
- * }
- *
  * @generated from service qdrant.cloud.auth.v2.AuthService
  */
 export const AuthService: GenService<{

--- a/gen/typescript/qdrant/cloud/backup/v1/backup_pb.ts
+++ b/gen/typescript/qdrant/cloud/backup/v1/backup_pb.ts
@@ -644,19 +644,6 @@ export const BackupScheduleSchema: GenMessage<BackupSchedule> = /*@__PURE__*/
 /**
  * BackupService is the API used to configure backup objects.
  *
- * TODO:
- * // Get the current API version of this service.
- * // Required permissions:
- * // - None (authenticated only)
- * rpc GetAPIVersion(GetAPIVersionRequest) returns (GetAPIVersionResponse) {
- * // permissions
- * option (common.v1.permissions) = "";
- * // custom account-id expression
- * option (qdrant.cloud.common.v1.account_id_expression) = "";
- * // gRPC Gateway REST call
- * option (google.api.http) = {get: "/api/backup/v1/api-version"};
- * }
- *
  * @generated from service qdrant.cloud.backup.v1.BackupService
  */
 export const BackupService: GenService<{

--- a/gen/typescript/qdrant/cloud/booking/v2/booking_pb.ts
+++ b/gen/typescript/qdrant/cloud/booking/v2/booking_pb.ts
@@ -85,7 +85,7 @@ export const ListPackagesResponseSchema: GenMessage<ListPackagesResponse> = /*@_
   messageDesc(file_qdrant_cloud_booking_v2_booking, 1);
 
 /**
- * GetAPIVersionRequest is the request for the GetAPIVersion function
+ * GetPackageRequest is the request for the GetPackage function
  *
  * @generated from message qdrant.cloud.booking.v2.GetPackageRequest
  */
@@ -243,19 +243,6 @@ export const ResourceConfigurationSchema: GenMessage<ResourceConfiguration> = /*
 
 /**
  * BookingService is the API used to configure the booking settings (like packages objects).
- *
- * TODO:
- * // Get the current API version of this service.
- * // Required permissions:
- * // - None (authenticated only)
- * rpc GetAPIVersion(GetAPIVersionRequest) returns (GetAPIVersionResponse) {
- * // permissions
- * option (common.v1.permissions) = "";
- * // custom account-id expression
- * option (qdrant.cloud.common.v1.account_id_expression) = "";
- * // gRPC Gateway REST call
- * option (google.api.http) = {get: "/api/booking/v2/api-version"};
- * }
  *
  * @generated from service qdrant.cloud.booking.v2.BookingService
  */

--- a/gen/typescript/qdrant/cloud/cluster/v2/cluster_pb.ts
+++ b/gen/typescript/qdrant/cloud/cluster/v2/cluster_pb.ts
@@ -1505,19 +1505,6 @@ export const ClusterJWTPayloadAccessListSchema: GenMessage<ClusterJWTPayloadAcce
 /**
  * ClusterService is the API used to configure cluster objects.
  *
- * TODO:
- * // Get the current API version of this service.
- * // Required permissions:
- * // - None (authenticated only)
- * rpc GetAPIVersion(GetAPIVersionRequest) returns (GetAPIVersionResponse) {
- * // permissions
- * option (common.v1.permissions) = "";
- * // custom account-id expression
- * option (qdrant.cloud.common.v1.account_id_expression) = "";
- * // gRPC Gateway REST call
- * option (google.api.http) = {get: "/api/cluster/v2/api-version"};
- * }
- *
  * @generated from service qdrant.cloud.cluster.v2.ClusterService
  */
 export const ClusterService: GenService<{

--- a/proto/qdrant/cloud/auth/v2/auth.proto
+++ b/proto/qdrant/cloud/auth/v2/auth.proto
@@ -9,20 +9,6 @@ import "qdrant/cloud/common/v1/common.proto";
 
 // AuthService is the API used to configure the auth settings (like api-key objects) for a cluster.
 service AuthService {
-  /* TODO:
-     // Get the current API version of this service.
-     // Required permissions:
-     // - None (authenticated only)
-     rpc GetAPIVersion(GetAPIVersionRequest) returns (GetAPIVersionResponse) {
-       // permissions
-       option (qdrant.cloud.common.v1.permissions) = "";
-       // custom account-id expression
-       option (qdrant.cloud.common.v1.account_id_expression) = "";
-       // gRPC Gateway REST call
-       option (google.api.http) = {get: "/api/auth/v2/api-version"};
-     }
-  */
-
   // Fetch all api-keys in the account identified by the given ID.
   // Required permissions:
   // - read:api_keys
@@ -60,19 +46,6 @@ service AuthService {
     option (google.api.http) = {delete: "/api/auth/v2/accounts/{account_id}/api-keys/{api_key_id}"};
   }
 }
-
-/* TODO:
-   // GetAPIVersionRequest is the request for the GetAPIVersion function
-   message GetAPIVersionRequest {
-     // Empty
-   }
-
-   // GetAPIVersionResponse is the response from the GetAPIVersion function
-   message GetAPIVersionResponse {
-     // The actual version
-     common.v1.Version version = 1;
-   }
-*/
 
 // ListApiKeysRequest is the request for the ListApiKeys function
 message ListApiKeysRequest {

--- a/proto/qdrant/cloud/backup/v1/backup.proto
+++ b/proto/qdrant/cloud/backup/v1/backup.proto
@@ -10,20 +10,6 @@ import "qdrant/cloud/common/v1/common.proto";
 
 // BackupService is the API used to configure backup objects.
 service BackupService {
-  /* TODO:
-     // Get the current API version of this service.
-     // Required permissions:
-     // - None (authenticated only)
-     rpc GetAPIVersion(GetAPIVersionRequest) returns (GetAPIVersionResponse) {
-       // permissions
-       option (common.v1.permissions) = "";
-       // custom account-id expression
-       option (qdrant.cloud.common.v1.account_id_expression) = "";
-       // gRPC Gateway REST call
-       option (google.api.http) = {get: "/api/backup/v1/api-version"};
-     }
-  */
-
   // Fetch all backups in the account identified by the given ID.
   // Required permissions:
   // - read:backups

--- a/proto/qdrant/cloud/booking/v2/booking.proto
+++ b/proto/qdrant/cloud/booking/v2/booking.proto
@@ -8,20 +8,6 @@ import "qdrant/cloud/common/v1/common.proto";
 
 // BookingService is the API used to configure the booking settings (like packages objects).
 service BookingService {
-  /* TODO:
-     // Get the current API version of this service.
-     // Required permissions:
-     // - None (authenticated only)
-     rpc GetAPIVersion(GetAPIVersionRequest) returns (GetAPIVersionResponse) {
-       // permissions
-       option (common.v1.permissions) = "";
-       // custom account-id expression
-       option (qdrant.cloud.common.v1.account_id_expression) = "";
-       // gRPC Gateway REST call
-       option (google.api.http) = {get: "/api/booking/v2/api-version"};
-     }
-  */
-
   // Fetch all packages known by the system, optional filtered.
   // Required permissions:
   // - None (authenticated only)
@@ -42,19 +28,6 @@ service BookingService {
     option (google.api.http) = {get: "/api/booking/v2/accounts/{account_id}/packages/{id}"};
   }
 }
-
-/* TODO:
-   // GetAPIVersionRequest is the request for the GetAPIVersion function
-   message GetAPIVersionRequest {
-     // Empty
-   }
-
-   // GetAPIVersionResponse is the response from the GetAPIVersion function
-   message GetAPIVersionResponse {
-     // The actual version
-     common.v1.Version version = 1;
-   }
-*/
 
 // ListPackagesRequest is the request for the ListPackages function
 message ListPackagesRequest {
@@ -91,7 +64,7 @@ message ListPackagesResponse {
   repeated Package items = 1;
 }
 
-// GetAPIVersionRequest is the request for the GetAPIVersion function
+// GetPackageRequest is the request for the GetPackage function
 message GetPackageRequest {
   // The identifier of the account (in Guid format).
   // This is a required field.

--- a/proto/qdrant/cloud/cluster/v2/cluster.proto
+++ b/proto/qdrant/cloud/cluster/v2/cluster.proto
@@ -9,20 +9,6 @@ import "qdrant/cloud/common/v1/common.proto";
 
 // ClusterService is the API used to configure cluster objects.
 service ClusterService {
-  /* TODO:
-     // Get the current API version of this service.
-     // Required permissions:
-     // - None (authenticated only)
-     rpc GetAPIVersion(GetAPIVersionRequest) returns (GetAPIVersionResponse) {
-       // permissions
-       option (common.v1.permissions) = "";
-       // custom account-id expression
-       option (qdrant.cloud.common.v1.account_id_expression) = "";
-       // gRPC Gateway REST call
-       option (google.api.http) = {get: "/api/cluster/v2/api-version"};
-     }
-  */
-
   // Fetch all clusters in the account identified by the given ID.
   // Required permissions:
   // - read:clusters
@@ -139,19 +125,6 @@ service ClusterService {
     option (google.api.http) = {delete: "/api/cluster/v2/accounts/{account_id}/clusters/{cluster_id}/jwts/{cluster_jwt_id}"};
   }
 }
-
-/* TODO:
-   // GetAPIVersionRequest is the request for the GetAPIVersion function
-   message GetAPIVersionRequest {
-     // Empty
-   }
-
-   // GetAPIVersionResponse is the response from the GetAPIVersion function
-   message GetAPIVersionResponse {
-     // The actual version
-     common.v1.Version version = 1;
-   }
-*/
 
 // ListClustersRequest is the request for the ListClusters function
 message ListClustersRequest {


### PR DESCRIPTION
The purpose of these methods was primarily to coordinate the depencies between services. At this moment we consider we still don't really needed it, and we prefer to add them once we have a clear use case.