### PR TITLE
Fix consuming API as package from git revision

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,8 +16,7 @@ Repository = "https://github.com/qdrant/qdrant-cloud-public-api"
 
 # Consider this as *happens in the time of `sdist` creation* i.e. at the time of packaging.
 [tool.hatch.build.targets.sdist]
-# Remove prefix from the generated sources, installed package will have the structure `qdrant/cloud`
-packages = ["gen/python/qdrant", "gen/python/google", "gen/python/buf"]
+include = ["gen/python/qdrant", "gen/python/google", "gen/python/buf"]
 
 [tool.hatch.build.targets.wheel]
 # Remove prefix from the generated sources, installed package will have the structure `qdrant/cloud`


### PR DESCRIPTION
`tool.hatch.build.targets.wheel` `packages` field should contain relatative path to exposed packages.

The package built with `uv build --wheel` contains now Python files.
