### PR TITLE
Make the position for `buf:lint:...` consistent as well as unauthenticated comments

### DIFF
--- a/gen/go/qdrant/cloud/booking/v1/booking_grpc.pb.go
+++ b/gen/go/qdrant/cloud/booking/v1/booking_grpc.pb.go
@@ -39,8 +39,7 @@ type BookingServiceClient interface {
 	// - None (authenticated only)
 	GetPackage(ctx context.Context, in *GetPackageRequest, opts ...grpc.CallOption) (*GetPackageResponse, error)
 	// Fetch all public packages
-	// Required permissions:
-	// - None (public endpoint)
+	// Authentication not required
 	ListGlobalPackages(ctx context.Context, in *ListGlobalPackagesRequest, opts ...grpc.CallOption) (*ListGlobalPackagesResponse, error)
 }
 
@@ -97,8 +96,7 @@ type BookingServiceServer interface {
 	// - None (authenticated only)
 	GetPackage(context.Context, *GetPackageRequest) (*GetPackageResponse, error)
 	// Fetch all public packages
-	// Required permissions:
-	// - None (public endpoint)
+	// Authentication not required
 	ListGlobalPackages(context.Context, *ListGlobalPackagesRequest) (*ListGlobalPackagesResponse, error)
 	mustEmbedUnimplementedBookingServiceServer()
 }

--- a/gen/go/qdrant/cloud/platform/v1/platform_grpc.pb.go
+++ b/gen/go/qdrant/cloud/platform/v1/platform_grpc.pb.go
@@ -32,12 +32,14 @@ const (
 // PlatformService is the API used to query for cloud provider & regional information.
 type PlatformServiceClient interface {
 	// Fetch all available cloud providers globally (not account-specific).
+	// Authentication is not required.
 	ListGlobalCloudProviders(ctx context.Context, in *ListGlobalCloudProvidersRequest, opts ...grpc.CallOption) (*ListGlobalCloudProvidersResponse, error)
 	// Fetch all cloud providers in the account identified by the given ID.
 	// Required permissions:
 	// - None (authenticated only)
 	ListCloudProviders(ctx context.Context, in *ListCloudProvidersRequest, opts ...grpc.CallOption) (*ListCloudProvidersResponse, error)
 	// Fetch all cloud provider regions (not account-specific) identified by cloud provider ID.
+	// Authentication is not required.
 	ListGlobalCloudProviderRegions(ctx context.Context, in *ListGlobalCloudProviderRegionsRequest, opts ...grpc.CallOption) (*ListGlobalCloudProviderRegionsResponse, error)
 	// Fetch all cloud provider regions in the account identified by the given ID and cloud provider.
 	// Required permissions:
@@ -100,12 +102,14 @@ func (c *platformServiceClient) ListCloudProviderRegions(ctx context.Context, in
 // PlatformService is the API used to query for cloud provider & regional information.
 type PlatformServiceServer interface {
 	// Fetch all available cloud providers globally (not account-specific).
+	// Authentication is not required.
 	ListGlobalCloudProviders(context.Context, *ListGlobalCloudProvidersRequest) (*ListGlobalCloudProvidersResponse, error)
 	// Fetch all cloud providers in the account identified by the given ID.
 	// Required permissions:
 	// - None (authenticated only)
 	ListCloudProviders(context.Context, *ListCloudProvidersRequest) (*ListCloudProvidersResponse, error)
 	// Fetch all cloud provider regions (not account-specific) identified by cloud provider ID.
+	// Authentication is not required.
 	ListGlobalCloudProviderRegions(context.Context, *ListGlobalCloudProviderRegionsRequest) (*ListGlobalCloudProviderRegionsResponse, error)
 	// Fetch all cloud provider regions in the account identified by the given ID and cloud provider.
 	// Required permissions:

--- a/gen/openapiv2/qdrant/cloud/account/v1/account.swagger.json
+++ b/gen/openapiv2/qdrant/cloud/account/v1/account.swagger.json
@@ -974,7 +974,7 @@
           "description": "The notification preferences of the user."
         }
       },
-      "title": "A User represents a user in the Qdrant cloud.\nbuf:lint:ignore QDRANT_CLOUD_REQUIRED_ENTITY_FIELDS"
+      "description": "A User represents a user in the Qdrant cloud."
     },
     "v1UserStatus": {
       "type": "string",

--- a/gen/openapiv2/qdrant/cloud/booking/v1/booking.swagger.json
+++ b/gen/openapiv2/qdrant/cloud/booking/v1/booking.swagger.json
@@ -119,7 +119,7 @@
     },
     "/api/booking/v1/packages": {
       "get": {
-        "summary": "Fetch all public packages\nRequired permissions:\n- None (public endpoint)\nbuf:lint:ignore QDRANT_CLOUD_METHOD_OPTIONS",
+        "summary": "Fetch all public packages\nAuthentication not required",
         "operationId": "BookingService_ListGlobalPackages",
         "responses": {
           "200": {

--- a/gen/openapiv2/qdrant/cloud/iam/v1/iam.swagger.json
+++ b/gen/openapiv2/qdrant/cloud/iam/v1/iam.swagger.json
@@ -882,7 +882,7 @@
           "description": "The notification preferences of the user."
         }
       },
-      "title": "A User represents a user in the Qdrant cloud.\nbuf:lint:ignore QDRANT_CLOUD_REQUIRED_ENTITY_FIELDS"
+      "description": "A User represents a user in the Qdrant cloud."
     },
     "v1UserConsentStatus": {
       "type": "string",

--- a/gen/openapiv2/qdrant/cloud/platform/v1/platform.swagger.json
+++ b/gen/openapiv2/qdrant/cloud/platform/v1/platform.swagger.json
@@ -89,7 +89,7 @@
     },
     "/api/platform/v1/cloud-providers": {
       "get": {
-        "summary": "Fetch all available cloud providers globally (not account-specific).",
+        "summary": "Fetch all available cloud providers globally (not account-specific).\nAuthentication is not required.",
         "operationId": "PlatformService_ListGlobalCloudProviders",
         "responses": {
           "200": {
@@ -112,7 +112,7 @@
     },
     "/api/platform/v1/cloud-providers/{cloudProviderId}/regions": {
       "get": {
-        "summary": "Fetch all cloud provider regions (not account-specific) identified by cloud provider ID.",
+        "summary": "Fetch all cloud provider regions (not account-specific) identified by cloud provider ID.\nAuthentication is not required.",
         "operationId": "PlatformService_ListGlobalCloudProviderRegions",
         "responses": {
           "200": {

--- a/gen/python/qdrant/cloud/booking/v1/booking_pb2_grpc.py
+++ b/gen/python/qdrant/cloud/booking/v1/booking_pb2_grpc.py
@@ -55,10 +55,9 @@ class BookingServiceServicer(object):
         raise NotImplementedError('Method not implemented!')
 
     def ListGlobalPackages(self, request, context):
-        """Fetch all public packages
-        Required permissions:
-        - None (public endpoint)
-        buf:lint:ignore QDRANT_CLOUD_METHOD_OPTIONS
+        """buf:lint:ignore QDRANT_CLOUD_METHOD_OPTIONS
+        Fetch all public packages
+        Authentication not required
         """
         context.set_code(grpc.StatusCode.UNIMPLEMENTED)
         context.set_details('Method not implemented!')

--- a/gen/python/qdrant/cloud/platform/v1/platform_pb2_grpc.py
+++ b/gen/python/qdrant/cloud/platform/v1/platform_pb2_grpc.py
@@ -44,6 +44,7 @@ class PlatformServiceServicer(object):
     def ListGlobalCloudProviders(self, request, context):
         """buf:lint:ignore QDRANT_CLOUD_METHOD_OPTIONS
         Fetch all available cloud providers globally (not account-specific).
+        Authentication is not required.
         """
         context.set_code(grpc.StatusCode.UNIMPLEMENTED)
         context.set_details('Method not implemented!')
@@ -61,6 +62,7 @@ class PlatformServiceServicer(object):
     def ListGlobalCloudProviderRegions(self, request, context):
         """buf:lint:ignore QDRANT_CLOUD_METHOD_OPTIONS
         Fetch all cloud provider regions (not account-specific) identified by cloud provider ID.
+        Authentication is not required.
         """
         context.set_code(grpc.StatusCode.UNIMPLEMENTED)
         context.set_details('Method not implemented!')

--- a/gen/typescript/qdrant/cloud/booking/v1/booking_pb.d.ts
+++ b/gen/typescript/qdrant/cloud/booking/v1/booking_pb.d.ts
@@ -374,8 +374,7 @@ export declare const BookingService: GenService<{
   },
   /**
    * Fetch all public packages
-   * Required permissions:
-   * - None (public endpoint)
+   * Authentication not required
    *
    * @generated from rpc qdrant.cloud.booking.v1.BookingService.ListGlobalPackages
    */

--- a/gen/typescript/qdrant/cloud/platform/v1/platform_pb.d.ts
+++ b/gen/typescript/qdrant/cloud/platform/v1/platform_pb.d.ts
@@ -292,6 +292,7 @@ export declare const CloudProviderRegionSchema: GenMessage<CloudProviderRegion>;
 export declare const PlatformService: GenService<{
   /**
    * Fetch all available cloud providers globally (not account-specific).
+   * Authentication is not required.
    *
    * @generated from rpc qdrant.cloud.platform.v1.PlatformService.ListGlobalCloudProviders
    */
@@ -314,6 +315,7 @@ export declare const PlatformService: GenService<{
   },
   /**
    * Fetch all cloud provider regions (not account-specific) identified by cloud provider ID.
+   * Authentication is not required.
    *
    * @generated from rpc qdrant.cloud.platform.v1.PlatformService.ListGlobalCloudProviderRegions
    */

--- a/proto/qdrant/cloud/account/v1/account.proto
+++ b/proto/qdrant/cloud/account/v1/account.proto
@@ -256,9 +256,9 @@ message ListAccountInvitesResponse {
   repeated AccountInvite items = 1;
 }
 
+// buf:lint:ignore QDRANT_CLOUD_REQUIRED_REQUEST_FIELDS
 // ListReceivedAccountInvitesRequest is the request for the ListReceivedAccountInvites function.
 // This lists invites for the authenticated user across all accounts.
-// buf:lint:ignore QDRANT_CLOUD_REQUIRED_REQUEST_FIELDS
 message ListReceivedAccountInvitesRequest {
   // Empty
 }

--- a/proto/qdrant/cloud/booking/v1/booking.proto
+++ b/proto/qdrant/cloud/booking/v1/booking.proto
@@ -26,10 +26,9 @@ service BookingService {
     // gRPC Gateway REST call
     option (google.api.http) = {get: "/api/booking/v1/accounts/{account_id}/packages/{id}"};
   }
-  // Fetch all public packages
-  // Required permissions:
-  // - None (public endpoint)
   // buf:lint:ignore QDRANT_CLOUD_METHOD_OPTIONS
+  // Fetch all public packages
+  // Authentication not required
   rpc ListGlobalPackages(ListGlobalPackagesRequest) returns (ListGlobalPackagesResponse) {
     // authentication not required
     option (qdrant.cloud.common.v1.requires_authentication) = false;
@@ -61,8 +60,8 @@ message ListPackagesResponse {
   repeated Package items = 1;
 }
 
-// ListGlobalPackagesRequest is the request for the ListGlobalPackages function
 // buf:lint:ignore QDRANT_CLOUD_REQUIRED_REQUEST_FIELDS
+// ListGlobalPackagesRequest is the request for the ListGlobalPackages function
 message ListGlobalPackagesRequest {
   // Mandatory filter specifying the cloud provider where the cluster will be hosted.
   // Must match one of the provider IDs returned by the `qdrant.cloud.platform.v1.PlatformService.ListGlobalCloudProviders` method.

--- a/proto/qdrant/cloud/iam/v1/iam.proto
+++ b/proto/qdrant/cloud/iam/v1/iam.proto
@@ -159,8 +159,8 @@ service IAMService {
   }
 }
 
-// GetAuthenticatedUserRequest is the request for the GetAuthenticatedUser function
 // buf:lint:ignore QDRANT_CLOUD_REQUIRED_REQUEST_FIELDS
+// GetAuthenticatedUserRequest is the request for the GetAuthenticatedUser function
 message GetAuthenticatedUserRequest {
   // Empty
 }
@@ -183,8 +183,8 @@ message UpdateUserResponse {
   User user = 1;
 }
 
-// GetUserConsentRequest is the request for the GetUserConsent function.
 // buf:lint:ignore QDRANT_CLOUD_REQUIRED_REQUEST_FIELDS
+// GetUserConsentRequest is the request for the GetUserConsent function.
 message GetUserConsentRequest {
   // The type of the legal document.
   // This is a required field and cannot be UNSPECIFIED.
@@ -349,8 +349,8 @@ message AssignUserRolesResponse {
   // Empty
 }
 
-// A User represents a user in the Qdrant cloud.
 // buf:lint:ignore QDRANT_CLOUD_REQUIRED_ENTITY_FIELDS
+// A User represents a user in the Qdrant cloud.
 message User {
   // Unique identifier for the user (in GUID format).
   // This is a read-only field and will be available after the user is created.

--- a/proto/qdrant/cloud/platform/v1/platform.proto
+++ b/proto/qdrant/cloud/platform/v1/platform.proto
@@ -10,6 +10,7 @@ import "qdrant/cloud/common/v1/common.proto";
 service PlatformService {
   // buf:lint:ignore QDRANT_CLOUD_METHOD_OPTIONS
   // Fetch all available cloud providers globally (not account-specific).
+  // Authentication is not required.
   rpc ListGlobalCloudProviders(ListGlobalCloudProvidersRequest) returns (ListGlobalCloudProvidersResponse) {
     // authentication not required
     option (qdrant.cloud.common.v1.requires_authentication) = false;
@@ -27,6 +28,7 @@ service PlatformService {
   }
   // buf:lint:ignore QDRANT_CLOUD_METHOD_OPTIONS
   // Fetch all cloud provider regions (not account-specific) identified by cloud provider ID.
+  // Authentication is not required.
   rpc ListGlobalCloudProviderRegions(ListGlobalCloudProviderRegionsRequest) returns (ListGlobalCloudProviderRegionsResponse) {
     // authentication not required
     option (qdrant.cloud.common.v1.requires_authentication) = false;


### PR DESCRIPTION
This makes the code/documentation a bit more consitent.