### PR TITLE
Generate package.json with 'version' and 'exports' fields using shell script

### DIFF
--- a/.github/actions/shared-setup/action.yml
+++ b/.github/actions/shared-setup/action.yml
@@ -37,5 +37,5 @@ runs:
         if [ "${INPUT_TARGET}" = "python" ]; then
           sed -i "s/^version = .*/version = \"$STRIPPED_VERSION\"/" pyproject.toml
         elif [ "${INPUT_TARGET}" = "node" ]; then
-          jq --arg version "$STRIPPED_VERSION" '.version = $version' package.example.json > tmp.$$.json && mv tmp.$$.json package.json
+          ./scripts/generate-package-package.json "$STRIPPED_VERSION"
         fi

--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ __pycache__/
 /gen-dummy
 node_modules/
 var/
+/package.json

--- a/package.example.json
+++ b/package.example.json
@@ -47,5 +47,7 @@
     "@connectrpc/connect-web": {
       "optional": true
     }
-  }
+  },
+  "exports": {},
+  "sideEffects": false
 }

--- a/scripts/generate-package-json.sh
+++ b/scripts/generate-package-json.sh
@@ -1,0 +1,97 @@
+#!/usr/bin/env sh
+
+set -eu
+
+# first argument is version and we want to check it is a valid semver
+if [ -z "${1:-}" ]; then
+    echo "Usage: $0 <semver-version>"
+    exit 1
+fi
+VERSION="$1"
+
+jq --arg version "$VERSION" '.version = $version' package.example.json > tmp.$$.json && mv tmp.$$.json package.json
+echo "Updated version to $VERSION in package.json"
+
+# Check if the directory exists before searching
+if [ ! -d "gen/typescript/qdrant/cloud" ]; then
+    echo "Directory gen/typescript/qdrant/cloud does not exist"
+    exit 1
+fi
+
+# Function to add export entry to package.json
+add_export() {
+    local key="$1"
+    local js_path="$2"
+    local ts_path="$3"
+    
+    jq --arg key "$key" \
+       --arg js_path "$js_path" \
+       --arg ts_path "$ts_path" \
+       '.exports[$key] = {
+         "import": $js_path,
+         "types": $ts_path
+       }' package.json > tmp.$$.json && mv tmp.$$.json package.json
+}
+
+# Function to convert .d.ts path to relative package paths
+get_package_paths() {
+    local dts_file="$1"
+    local js_path ts_path
+    
+    ts_path=$(echo "$dts_file" | sed 's|^gen/typescript/|./|')
+    js_path=$(echo "$ts_path" | sed 's/\.d\.ts$/.js/')
+    
+    echo "$js_path|$ts_path"
+}
+
+# Find all .d.ts files and process them
+find gen/typescript/qdrant/cloud -name "*.d.ts" -type f | \
+while read -r dts_file; do
+    # Skip if corresponding .js file doesn't exist
+    js_file=$(echo "$dts_file" | sed 's/\.d\.ts$/.js/')
+    [ ! -f "$js_file" ] && continue
+    
+    # Get paths
+    paths=$(get_package_paths "$dts_file")
+    js_path=$(echo "$paths" | cut -d'|' -f1)
+    ts_path=$(echo "$paths" | cut -d'|' -f2)
+    
+    # Extract service and potential submodule from path
+    rel_path=$(echo "$dts_file" | sed 's|gen/typescript/qdrant/cloud/||')
+    service=$(echo "$rel_path" | cut -d'/' -f1)
+    submodule=$(echo "$rel_path" | cut -d'/' -f2)
+    version=$(echo "$rel_path" | cut -d'/' -f3)
+    filename=$(basename "$dts_file" .d.ts)
+    
+    # Determine if this is a direct service or has submodules
+    # Count how many levels deep we are (service/version/file vs service/submodule/version/file)
+    num_levels=$(echo "$rel_path" | tr '/' '\n' | wc -l)
+    
+    if [ "$num_levels" -le 3 ]; then
+        # Direct service: service/version/file (e.g., auth/v1/auth_pb.d.ts)
+        if echo "$filename" | grep -q "_connectquery$"; then
+            export_key="$service/connect-query"
+            sort_prefix="$service-1"
+        else
+            export_key="$service"
+            sort_prefix="$service-0"
+        fi
+    else
+        # Has submodules: service/submodule/version/file (e.g., cluster/auth/v1/file.d.ts)
+        if echo "$filename" | grep -q "_connectquery$"; then
+            export_key="$service/$submodule/connect-query"
+            sort_prefix="$service-$submodule-1"
+        else
+            export_key="$service/$submodule"
+            sort_prefix="$service-$submodule-0"
+        fi
+    fi
+    
+    echo "$sort_prefix|$export_key|$js_path|$ts_path"
+done | \
+sort | \
+while IFS='|' read -r sort_prefix export_key js_path ts_path; do
+    add_export "$export_key" "$js_path" "$ts_path"
+done
+
+echo "Generated exports for package.json"

--- a/scripts/generate-package-json.sh
+++ b/scripts/generate-package-json.sh
@@ -109,20 +109,20 @@ while read -r dts_file; do
     if [ -z "$submodules" ]; then
         # Direct service: service/version/file (e.g., auth/v1/auth_pb.d.ts)
         if echo "$filename" | grep -q "_connectquery$"; then
-            export_key="$version/$service/connect-query"
+            export_key="$service/$version/connect-query"
             sort_prefix="$service-$version-1"
         else
-            export_key="$version/$service"
+            export_key="$service/$version"
             sort_prefix="$service-$version-0"
         fi
     else
         # Has submodules: service/submodule(s)/version/file (e.g., cluster/auth/v1/file.d.ts, serverless/collection/auth/v1/file.d.ts)
         submodules_normalized=$(echo "$submodules" | tr '/' '-')
         if echo "$filename" | grep -q "_connectquery$"; then
-            export_key="$version/$service/$submodules/connect-query"
+            export_key="$service/$submodules/$version/connect-query"
             sort_prefix="$service-$version-$submodules_normalized-1"
         else
-            export_key="$version/$service/$submodules"
+            export_key="$service/$submodules/$version"
             sort_prefix="$service-$version-$submodules_normalized-0"
         fi
     fi


### PR DESCRIPTION
Ref: https://qdrant.atlassian.net/browse/CF-973

### NPM package entry points

Without an entry point for the package, editor auto-complete for imports do not work, and typing deep paths is cumbersome. This PR aims to improve module discoverability, import readability and developer experience.

>The ["exports"](https://nodejs.org/api/packages.html#exports) provides a modern alternative to ["main"](https://nodejs.org/api/packages.html#main) allowing multiple entry points to be defined, conditional entry resolution support between environments, and preventing any other entry points besides those defined in ["exports"](https://nodejs.org/api/packages.html#exports). This encapsulation allows module authors to clearly define the public interface for their package.
> https://nodejs.org/api/packages.html#package-entry-points

#### Example import

```js
import { ListAccountsResponseSchema } from '@qdrant/qdrant-cloud-public-api/v1/account';
import { listAccounts } from '@qdrant/qdrant-cloud-public-api/v1/account/connect-query';
import * as serverlessCQ from '@qdrant/qdrant-cloud-public-api/v1/serverless/collection/auth/connect-query';
```


#### package.json

```json
{
  "name": "@qdrant/qdrant-cloud-public-api",
  "version": "1.0.0",
  "//": "[...]",
  "devDependencies": {
    "typescript": "^5.8.3"
  },
  "dependencies": {
    "@bufbuild/protobuf": "^2.6.0"
  },
  "peerDependencies": {
    "@connectrpc/connect": "^2.0.2",
    "@connectrpc/connect-node": "^2.0.2",
    "@connectrpc/connect-query": "^2.1.0",
    "@connectrpc/connect-web": "^2.0.2"
  },
  "peerDependenciesMeta": {
    "@connectrpc/connect": {
      "optional": true
    },
    "@connectrpc/connect-node": {
      "optional": true
    },
    "@connectrpc/connect-query": {
      "optional": true
    },
    "@connectrpc/connect-web": {
      "optional": true
    }
  },
"exports": {
    "./account/v1": {
      "import": "./qdrant/cloud/account/v1/account_pb.js",
      "types": "./qdrant/cloud/account/v1/account_pb.d.ts"
    },
    "./account/v1/connect-query": {
      "import": "./qdrant/cloud/account/v1/account-AccountService_connectquery.js",
      "types": "./qdrant/cloud/account/v1/account-AccountService_connectquery.d.ts"
    },
    "./auth/v1": {
      "import": "./qdrant/cloud/auth/v1/auth_pb.js",
      "types": "./qdrant/cloud/auth/v1/auth_pb.d.ts"
    },
    "./auth/v1/connect-query": {
      "import": "./qdrant/cloud/auth/v1/auth-AuthService_connectquery.js",
      "types": "./qdrant/cloud/auth/v1/auth-AuthService_connectquery.d.ts"
    },
    "./booking/v1": {
      "import": "./qdrant/cloud/booking/v1/booking_pb.js",
      "types": "./qdrant/cloud/booking/v1/booking_pb.d.ts"
    },
    "./booking/v1/connect-query": {
      "import": "./qdrant/cloud/booking/v1/booking-BookingService_connectquery.js",
      "types": "./qdrant/cloud/booking/v1/booking-BookingService_connectquery.d.ts"
    },
    "./cluster/v1": {
      "import": "./qdrant/cloud/cluster/v1/cluster_pb.js",
      "types": "./qdrant/cloud/cluster/v1/cluster_pb.d.ts"
    },
    "./cluster/v1/connect-query": {
      "import": "./qdrant/cloud/cluster/v1/cluster-ClusterService_connectquery.js",
      "types": "./qdrant/cloud/cluster/v1/cluster-ClusterService_connectquery.d.ts"
    },
    "./cluster/auth/v1": {
      "import": "./qdrant/cloud/cluster/auth/v1/database_api_key_pb.js",
      "types": "./qdrant/cloud/cluster/auth/v1/database_api_key_pb.d.ts"
    },
    "./cluster/auth/v1/connect-query": {
      "import": "./qdrant/cloud/cluster/auth/v1/database_api_key-DatabaseApiKeyService_connectquery.js",
      "types": "./qdrant/cloud/cluster/auth/v1/database_api_key-DatabaseApiKeyService_connectquery.d.ts"
    },
    "./cluster/backup/v1": {
      "import": "./qdrant/cloud/cluster/backup/v1/backup_pb.js",
      "types": "./qdrant/cloud/cluster/backup/v1/backup_pb.d.ts"
    },
    "./cluster/backup/v1/connect-query": {
      "import": "./qdrant/cloud/cluster/backup/v1/backup-BackupService_connectquery.js",
      "types": "./qdrant/cloud/cluster/backup/v1/backup-BackupService_connectquery.d.ts"
    },
    "./cluster/auth/v2": {
      "import": "./qdrant/cloud/cluster/auth/v2/database_api_key_pb.js",
      "types": "./qdrant/cloud/cluster/auth/v2/database_api_key_pb.d.ts"
    },
    "./cluster/auth/v2/connect-query": {
      "import": "./qdrant/cloud/cluster/auth/v2/database_api_key-DatabaseApiKeyService_connectquery.js",
      "types": "./qdrant/cloud/cluster/auth/v2/database_api_key-DatabaseApiKeyService_connectquery.d.ts"
    },
    "./common/v1": {
      "import": "./qdrant/cloud/common/v1/common_pb.js",
      "types": "./qdrant/cloud/common/v1/common_pb.d.ts"
    },
    "./hybrid/v1": {
      "import": "./qdrant/cloud/hybrid/v1/hybrid_cloud_pb.js",
      "types": "./qdrant/cloud/hybrid/v1/hybrid_cloud_pb.d.ts"
    },
    "./hybrid/v1/connect-query": {
      "import": "./qdrant/cloud/hybrid/v1/hybrid_cloud-HybridCloudService_connectquery.js",
      "types": "./qdrant/cloud/hybrid/v1/hybrid_cloud-HybridCloudService_connectquery.d.ts"
    },
    "./iam/v1": {
      "import": "./qdrant/cloud/iam/v1/iam_pb.js",
      "types": "./qdrant/cloud/iam/v1/iam_pb.d.ts"
    },
    "./iam/v1/connect-query": {
      "import": "./qdrant/cloud/iam/v1/iam-IAMService_connectquery.js",
      "types": "./qdrant/cloud/iam/v1/iam-IAMService_connectquery.d.ts"
    },
    "./monitoring/v1": {
      "import": "./qdrant/cloud/monitoring/v1/monitoring_pb.js",
      "types": "./qdrant/cloud/monitoring/v1/monitoring_pb.d.ts"
    },
    "./monitoring/v1/connect-query": {
      "import": "./qdrant/cloud/monitoring/v1/monitoring-MonitoringService_connectquery.js",
      "types": "./qdrant/cloud/monitoring/v1/monitoring-MonitoringService_connectquery.d.ts"
    },
    "./platform/v1": {
      "import": "./qdrant/cloud/platform/v1/platform_pb.js",
      "types": "./qdrant/cloud/platform/v1/platform_pb.d.ts"
    },
    "./platform/v1/connect-query": {
      "import": "./qdrant/cloud/platform/v1/platform-PlatformService_connectquery.js",
      "types": "./qdrant/cloud/platform/v1/platform-PlatformService_connectquery.d.ts"
    },
    "./serverless/collection/v1": {
      "import": "./qdrant/cloud/serverless/collection/v1/collection_pb.js",
      "types": "./qdrant/cloud/serverless/collection/v1/collection_pb.d.ts"
    },
    "./serverless/collection/v1/connect-query": {
      "import": "./qdrant/cloud/serverless/collection/v1/collection-CollectionService_connectquery.js",
      "types": "./qdrant/cloud/serverless/collection/v1/collection-CollectionService_connectquery.d.ts"
    },
    "./serverless/collection/auth/v1": {
      "import": "./qdrant/cloud/serverless/collection/auth/v1/collection_api_key_pb.js",
      "types": "./qdrant/cloud/serverless/collection/auth/v1/collection_api_key_pb.d.ts"
    },
    "./serverless/collection/auth/v1/connect-query": {
      "import": "./qdrant/cloud/serverless/collection/auth/v1/collection_api_key-CollectionApiKeyService_connectquery.js",
      "types": "./qdrant/cloud/serverless/collection/auth/v1/collection_api_key-CollectionApiKeyService_connectquery.d.ts"
    }
  },
  "sideEffects": false
}

```