### PR TITLE
Add `skip-existing` option when uploading python pkg

### DIFF
--- a/.github/workflows/release-workflow.yaml
+++ b/.github/workflows/release-workflow.yaml
@@ -51,6 +51,7 @@ jobs:
           uv build
           uv run twine upload \
             --repository-url https://us-python.pkg.dev/qdrant-cloud/python/ \
+            --skip-existing \
             --username oauth2accesstoken \
             --password "$(gcloud auth print-access-token)" \
             dist/*


### PR DESCRIPTION
In case the release workflow fails for something else (e,g. releasing npm package), with this change the upload process doesn't fail if the python package has been already uploaded.