### PR TITLE
Sets the name of the tag to the release version

### DIFF
--- a/.github/workflows/release-workflow.yaml
+++ b/.github/workflows/release-workflow.yaml
@@ -134,6 +134,7 @@ jobs:
           disable-autolabeler: true
           commitish: ${{ github.ref }}
           tag: ${{ env.RELEASE_VERSION }}
+          name: ${{ env.RELEASE_VERSION }}
           publish: true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Otherwise GitHub makes a title (name) from the content of the release.

Like this
<img width="819" height="140" alt="image" src="https://github.com/user-attachments/assets/71c1a6a5-b606-4033-aa07-b9693f0078a5" />

xref: https://github.com/release-drafter/release-drafter?tab=readme-ov-file#action-inputs
