### PR TITLE
feat(backup): add restore package id and resources to cluster info

### DIFF
--- a/proto/qdrant/cloud/cluster/backup/v1/backup.proto
+++ b/proto/qdrant/cloud/cluster/backup/v1/backup.proto
@@ -489,6 +489,11 @@ message ClusterInfo {
   };
   // The cluster configuration at the time of backup.
   qdrant.cloud.cluster.v1.ClusterConfiguration configuration = 4 [(buf.validate.field).required = true];
+  // The identifier of the best package to use for a restore into new cluster
+  // could be the same package_id as original, alternative with same cpu,ram,disk or None
+  optional string restore_package_id = 5 [(buf.validate.field).string = {uuid: true}];
+  // Resources of the original cluster
+  qdrant.cloud.cluster.v1.ClusterNodeResourcesSummary resources = 6 [(buf.validate.field).required = true];
 }
 
 // BackupScheduleStatus represents the current status of a backup schedule.


### PR DESCRIPTION
Add optional restore_package_id and required resources fields to ClusterInfo message to support better restore functionality