### PR TITLE
[CP-302] Add optional status filter to ListAccountInvites 

### DIFF
--- a/proto/qdrant/cloud/account/v1/account.proto
+++ b/proto/qdrant/cloud/account/v1/account.proto
@@ -366,6 +366,10 @@ message ListAccountInvitesRequest {
   // The identifier of the account (in GUID format) to list invites for.
   // This is a required field.
   string account_id = 1 [(buf.validate.field).string = {uuid: true}];
+  // The status of the account invite to filter.
+  // This is an optional field. If value is not set, all statuses are returned.
+  repeated AccountInviteStatus statuses = 2;
+
 }
 
 // ListAccountInvitesResponse is the response from the ListAccountInvites function.


### PR DESCRIPTION
For user convenience we need to support filtering by status. This way users will be able to list the invites interesting for them. 